### PR TITLE
Redesign record_transaction method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/coverage/*

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -1,0 +1,9 @@
+class Account
+
+  attr_reader :balance
+
+  def initialize
+    @balance = 0
+  end
+
+end

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -20,17 +20,9 @@ class Account
   private
 
   def record_transaction(amount, date, type)
-    if type == :credit
-      credit = amount.to_f
-      debit = nil
-    else
-      credit = nil
-      debit = amount.to_f
-    end
     @transactions.push(
       date: date,
-      credit: credit,
-      debit: debit,
+      type => amount,
       balance: @balance.to_f
     )
   end

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -1,5 +1,5 @@
+# Simple checking account
 class Account
-
   attr_reader :balance
 
   def initialize
@@ -8,19 +8,31 @@ class Account
   end
 
   def deposit(amount, date)
-    record_transaction(amount, date, :debit)
     increase_balance(amount)
+    record_transaction(amount, date, :credit)
   end
 
   def withdraw(amount, date)
-    record_transaction(amount, date, :credit)
     decrease_balance(amount)
+    record_transaction(amount, date, :debit)
   end
 
   private
 
   def record_transaction(amount, date, type)
-    @transactions.push({amount: amount, date: date, type: type})
+    if type == :credit
+      credit = amount.to_f
+      debit = nil
+    else
+      credit = nil
+      debit = amount.to_f
+    end
+    @transactions.push(
+      date: date,
+      credit: credit,
+      debit: debit,
+      balance: @balance.to_f
+    )
   end
 
   def increase_balance(amount)
@@ -30,5 +42,4 @@ class Account
   def decrease_balance(amount)
     @balance -= amount
   end
-
 end

--- a/lib/account.rb
+++ b/lib/account.rb
@@ -4,6 +4,31 @@ class Account
 
   def initialize
     @balance = 0
+    @transactions = []
+  end
+
+  def deposit(amount, date)
+    record_transaction(amount, date, :debit)
+    increase_balance(amount)
+  end
+
+  def withdraw(amount, date)
+    record_transaction(amount, date, :credit)
+    decrease_balance(amount)
+  end
+
+  private
+
+  def record_transaction(amount, date, type)
+    @transactions.push({amount: amount, date: date, type: type})
+  end
+
+  def increase_balance(amount)
+    @balance += amount
+  end
+
+  def decrease_balance(amount)
+    @balance -= amount
   end
 
 end

--- a/lib/statement.rb
+++ b/lib/statement.rb
@@ -1,0 +1,31 @@
+# Formats and displays an account statement
+class Statement
+  def initialize(transactions)
+    @transactions = transactions
+  end
+
+  def display
+    header + sorted_by_date.map { |transaction| format_line(transaction) }.join
+  end
+
+  private
+
+  def sorted_by_date
+    @transactions.sort { |a, b| b[:date] <=> a[:date] }
+  end
+
+  def header
+    "date || credit || debit || balance\n"
+  end
+
+  def format_line(transaction)
+    "#{transaction[:date]} || " \
+      "#{format_currency(transaction[:credit])} || " \
+      "#{format_currency(transaction[:debit])} || " \
+      "#{format_currency(transaction[:balance])}\n"
+  end
+
+  def format_currency(amount)
+    format(format('%.2f', amount)) if amount
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,11 @@ require 'rspec'
 require 'simplecov'
 require 'simplecov-console'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::Console])
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [SimpleCov::Formatter::Console]
+)
 SimpleCov.start do
-  add_filter "spec"
+  add_filter 'spec'
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,9 @@ require 'simplecov'
 require 'simplecov-console'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::Console])
-SimpleCov.start
+SimpleCov.start do
+  add_filter "spec"
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/units/account_spec.rb
+++ b/spec/units/account_spec.rb
@@ -1,8 +1,7 @@
 require 'account'
 
 describe 'Account' do
-
-  let(:account) { Account.new() }
+  let(:account) { Account.new }
 
   it 'has a balance' do
     expect(account.balance).to eq(0)

--- a/spec/units/account_spec.rb
+++ b/spec/units/account_spec.rb
@@ -1,0 +1,10 @@
+require 'account'
+
+describe 'Account' do
+
+  let(:account) { Account.new() }
+
+  it 'has a balance' do
+    expect(account.balance).to eq(0)
+  end
+end

--- a/spec/units/account_spec.rb
+++ b/spec/units/account_spec.rb
@@ -7,4 +7,15 @@ describe 'Account' do
   it 'has a balance' do
     expect(account.balance).to eq(0)
   end
+
+  it 'can take a deposit on a specified date' do
+    account.deposit(1000, '10/01/2012')
+    expect(account.balance).to eq(1000)
+  end
+
+  it 'can make a withdrawal on a specified date' do
+    account.deposit(1000, '10/01/2012')
+    account.withdraw(500, '14/01/2012')
+    expect(account.balance).to eq(500)
+  end
 end

--- a/spec/units/statement_spec.rb
+++ b/spec/units/statement_spec.rb
@@ -2,9 +2,9 @@ require 'statement'
 
 describe 'Statement' do
   let(:transactions) do
-    [{ date: '10/01/2012', credit: 1000.00, debit: nil, balance: 1000.00 },
-     { date: '13/01/2012', credit: 2000.00, debit: nil, balance: 3000.00 },
-     { date: '14/01/2012', credit: nil, debit: 500.00, balance: 2500.00 }]
+    [{ date: '10/01/2012', credit: 1000.00, balance: 1000.00 },
+     { date: '13/01/2012', credit: 2000.00, balance: 3000.00 },
+     { date: '14/01/2012', debit: 500.00, balance: 2500.00 }]
   end
 
   it 'can generate a statement for an account' do

--- a/spec/units/statement_spec.rb
+++ b/spec/units/statement_spec.rb
@@ -1,0 +1,17 @@
+require 'statement'
+
+describe 'Statement' do
+  let(:transactions) do
+    [{ date: '10/01/2012', credit: 1000.00, debit: nil, balance: 1000.00 },
+     { date: '13/01/2012', credit: 2000.00, debit: nil, balance: 3000.00 },
+     { date: '14/01/2012', credit: nil, debit: 500.00, balance: 2500.00 }]
+  end
+
+  it 'can generate a statement for an account' do
+    statement = Statement.new(transactions)
+    expect(statement.display).to eq("date || credit || debit || balance\n" \
+      "14/01/2012 ||  || 500.00 || 2500.00\n" \
+      "13/01/2012 || 2000.00 ||  || 3000.00\n" \
+      "10/01/2012 || 1000.00 ||  || 1000.00\n")
+  end
+end


### PR DESCRIPTION
Change design of account#record_transaction to only record debit or credit as appropriate, instead of recording both, one with the amount and the other as nil